### PR TITLE
Display only outdated packages in the result

### DIFF
--- a/src/DotNetOutdated/Program.cs
+++ b/src/DotNetOutdated/Program.cs
@@ -30,7 +30,10 @@ namespace DotNetOutdated
                 var package = responses[i];
                 var status = DependencyStatus.Check(dependency, package);
 
-                data.Add(status);
+                if (status.LatestVersion > status.Dependency.CurrentVersion)
+                {
+                    data.Add(status);
+                }
             }
 
             data.ToStringTable(


### PR DESCRIPTION
If a project has a lot of packages the result is very hard to parse as a lot of packages don't have a newer version available.

This PR changes this to only show packages where there is a version available that is higher than the current version