### PR TITLE
Refactor to use a single HttpClient

### DIFF
--- a/src/DotNetOutdated/HttpNuGetClient.cs
+++ b/src/DotNetOutdated/HttpNuGetClient.cs
@@ -6,20 +6,24 @@ using Newtonsoft.Json.Linq;
 
 namespace DotNetOutdated
 {
-    public class HttpNuGetClient : NuGetClient
+    public class HttpNuGetClient : V3NuGetClient
     {
+        private readonly HttpClient _httpClient;
+
+        public HttpNuGetClient(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
         protected override async Task<JObject> GetResource(string name)
         {
-            using (var client = new HttpClient())
-            {
-                var response = await client.GetAsync($"https://api.nuget.org/v3/registration3/{name}");
+            var response = await _httpClient.GetAsync($"https://api.nuget.org/v3/registration3/{name}");
 
-                if (response.IsSuccessStatusCode)
-                {
-                    return JObject.Parse(await response.Content.ReadAsStringAsync());
-                }
-                return null;
+            if (response.IsSuccessStatusCode)
+            {
+                return JObject.Parse(await response.Content.ReadAsStringAsync());
             }
+            return null;
         }
     }
 }

--- a/src/DotNetOutdated/V3NuGetClient.cs
+++ b/src/DotNetOutdated/V3NuGetClient.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace DotNetOutdated
 {
-    public abstract class NuGetClient
+    public abstract class V3NuGetClient
     {
         protected abstract Task<JObject> GetResource(string name);
 

--- a/test/DotNetOutdated.Test/FileSystemNuGetClient.cs
+++ b/test/DotNetOutdated.Test/FileSystemNuGetClient.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 
 namespace DotNetOutdated.Test
 {
-    public class FileSystemNuGetClient : NuGetClient
+    public class FileSystemNuGetClient : V3NuGetClient
     {
         protected override Task<JObject> GetResource(string name)
         {

--- a/test/DotNetOutdated.Test/MissingPackageNuGetClient.cs
+++ b/test/DotNetOutdated.Test/MissingPackageNuGetClient.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace DotNetOutdated.Test
 {
-    public class MissingPackageNuGetClient : NuGetClient
+    public class MissingPackageNuGetClient : V3NuGetClient
     {
         protected override Task<JObject> GetResource(string name) => Task.FromResult((JObject)null);
     }


### PR DESCRIPTION
I have also renamed the NuGetClient to V3NuGetClient in anticipation for
adding support for V2 clients.